### PR TITLE
fix: support dsh 0.1.2-alpha.1 (CallId -> ToolCallId rename in dsh-llm)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **Compatibility with dsh 0.1.2-alpha.1** — `@deepseek-ai/dsh-llm` renamed its `CallId` brand to `ToolCallId` (upstream commit `a789637db6`). The adapter now imports and uses `ToolCallId`, and the `@deepseek-ai/dsh-llm` peer range is tightened to `^0.1.2-alpha.1`, the only release line that ships the renamed export. Installations on earlier dsh lines (`≤ 0.1.1-rc.2`) should stay on `0.9.1`.
+
 ## [0.9.1] - 2026-08-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@deepseek-ai/dsh-commands": "^0.1.0-rc.6 || ^0.1.1-rc.1",
     "@deepseek-ai/dsh-credentials": "^0.1.0-rc.6 || ^0.1.1-rc.1",
     "@deepseek-ai/dsh-launch-environment": "^0.1.0-rc.6 || ^0.1.1-rc.1",
-    "@deepseek-ai/dsh-llm": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+    "@deepseek-ai/dsh-llm": "^0.1.2-alpha.1",
     "@deepseek-ai/dsh-settings": "^0.1.0-rc.6 || ^0.1.1-rc.1",
     "@deepseek-ai/dsh-timeout": "^0.1.0-rc.6 || ^0.1.1-rc.1",
     "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6 || ^0.1.1-rc.1",

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -30,7 +30,7 @@ import type { AttachmentStore, ImageAttachmentRef } from '@deepseek-ai/dsh-attac
 
 import {
   attributionHeaders,
-  CallId,
+  ToolCallId,
   LlmAdapter,
   LlmError,
   ReasoningEffortId,
@@ -1782,11 +1782,11 @@ export class CommandCodeAdapter<C extends CommandCodeConnectionOptions = Command
           sawContent = true
           chunks.push(
             { type: 'block-start', index, blockType: 'tool-call' },
-            { type: 'tool-call-delta', index, id: CallId(id), name, argumentsDelta: args },
+            { type: 'tool-call-delta', index, id: ToolCallId(id), name, argumentsDelta: args },
             {
               type: 'block-end',
               index,
-              block: { type: 'tool-call', id: CallId(id), name, arguments: args },
+              block: { type: 'tool-call', id: ToolCallId(id), name, arguments: args },
             },
           )
           break


### PR DESCRIPTION
## Summary

Fixes the plugin failing to load on **dsh 0.1.2-alpha.1** (the current release) with:

```
Error: failed to import loader entry llm-commandcode (@mars-sea/dsh-commandcode-provider):
The requested module '@deepseek-ai/dsh-llm' does not provide an export named 'CallId'
```

## Root cause

`@deepseek-ai/dsh-llm` renamed its `CallId` brand to `ToolCallId` in dsh **0.1.2-alpha.1** (deepseek-harness commit `a789637db6`, "refactor(llm): rename CallId to ToolCallId"). That rename exists **only** in the `0.1.2-alpha.1` line — every published `dsh-llm` before it (≤ `0.1.1-rc.2`) still exports `CallId`. The adapter imported the old name, so ESM instantiation fails at boot on the latest dsh.

The plugin's peer range (`^0.1.0-rc.6 || ^0.1.1-rc.1`) semver-matches `0.1.2-alpha.1`, so npm/pnpm install it without warning and the failure only shows up at runtime.

## Changes

- `src/adapter.ts` — import and use `ToolCallId` instead of `CallId` (both are brand functions with the identical `(id: string) => Branded<...>` signature, so this is a drop-in rename; the two call sites produce `tool-call`/`tool-call-delta` ids consumed by dsh-llm).
- `package.json` — tighten the `@deepseek-ai/dsh-llm` peer range to `^0.1.2-alpha.1`, the only release line shipping the renamed export. Installations on earlier dsh lines (≤ `0.1.1-rc.2`) must stay on `0.9.1`.
- `CHANGELOG.md` — entry under `[Unreleased]`.

## Validation

- Built the bundle (`npm run build`, tsdown) and confirmed `lib/index.js` imports `ToolCallId` with no stale `CallId` import.
- ESM load test of the built bundle against `@deepseek-ai/dsh-llm` **0.1.2-alpha.1** (monorepo checkout): module instantiates cleanly — the exact failure mode from the boot error is gone.
- Installed the local build into the `web` profile (`dsh plugin --profile web add <path>` → `link:` dependency, listed by `dsh plugin list`).

## Notes for the maintainer

- **CI/typecheck caveat:** `@deepseek-ai/dsh-llm` `0.1.2-alpha.1` is not published to npm yet (only the git tag exists), so `devDependencies` were intentionally left at `^0.1.0-rc.6`. CI will install fine but `npm run typecheck` will fail on the missing `ToolCallId` export until dsh publishes the `0.1.2-alpha.1` line (or a newer one) — after that, bump the `devDependencies` for `@deepseek-ai/dsh-llm` to `^0.1.2-alpha.1` as well.
- The other `dsh-*` imports used by the plugin (`LlmAdapter`, `LlmError`, `ReasoningEffortId`, `assertUsableApiKey`, `attributionHeaders`, `errorChain`, `resolveRetryPolicy`) all still exist in `dsh-llm 0.1.2-alpha.1`; the rename was the only breaking change affecting this plugin.
