### PR TITLE
fix(compat): support dsh 0.1.2-alpha.2 host APIs with rc fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **dsh 0.1.2-alpha.2 compatibility (host side).** The host entry now loads on the current `@alpha` runtime while staying backward-compatible with the rc channel: the tool-call id brand is resolved at runtime (`ToolCallId` on alpha, `CallId` on rc), and the settings section registers through `SettingsProvider.installSection` (`ctx.inject(['settings'])`, plain-string namespace) when the runtime ships it, falling back to the removed `installSettingsSection`/`settingsNamespace` helpers otherwise.
+
+### Removed
+
+- **Client bundle manifest entry (temporary).** The web client still targets the rc.2-era module table (`@deepseek-ai/dsh-client-runtime/client`, `@deepseek-ai/dsh-client-ui-primitives`), which no longer exists in the alpha.2 runtime — loading it aborts the whole client bootstrap (white page). The `dsh.client` manifest entry is removed so the plugin installs cleanly on alpha.2 with its host-side features; `src/client/` is kept for a future re-port against the current client-modules table.
+
 ## [0.9.1] - 2026-08-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -19,19 +19,6 @@
   "dsh": {
     "bundle": {
       "patch": "./cordis.patch.yml"
-    },
-    "client": {
-      "inject": [
-        "@deepseek-ai/dsh-client-connection",
-        "@deepseek-ai/dsh-client-runtime",
-        "@deepseek-ai/dsh-client-locale",
-        "@deepseek-ai/dsh-client-ui-settings",
-        "@deepseek-ai/dsh-api-remotes"
-      ],
-      "external": [
-        "@deepseek-ai/dsh-client-runtime/client"
-      ],
-      "platform": "web"
     }
   },
   "files": [

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -28,9 +28,9 @@ import { randomUUID } from 'node:crypto'
 
 import type { AttachmentStore, ImageAttachmentRef } from '@deepseek-ai/dsh-attachment'
 
+import * as dshLlm from '@deepseek-ai/dsh-llm'
 import {
   attributionHeaders,
-  CallId,
   LlmAdapter,
   LlmError,
   ReasoningEffortId,
@@ -47,6 +47,11 @@ import {
   type StreamChunk,
   type TokenUsage,
 } from '@deepseek-ai/dsh-llm'
+
+// dsh-llm 0.1.2-alpha.2 renamed the CallId brand function to ToolCallId. Pick
+// whichever the runtime provides so the adapter loads on both the rc and alpha
+// channels (the peer range admits both).
+const brandCallId = (dshLlm as any).ToolCallId ?? (dshLlm as any).CallId
 import { RETRY_MAX_DELAY_MS } from './accounts.ts'
 
 // ---------------------------------------------------------------------------
@@ -1782,11 +1787,11 @@ export class CommandCodeAdapter<C extends CommandCodeConnectionOptions = Command
           sawContent = true
           chunks.push(
             { type: 'block-start', index, blockType: 'tool-call' },
-            { type: 'tool-call-delta', index, id: CallId(id), name, argumentsDelta: args },
+            { type: 'tool-call-delta', index, id: brandCallId(id), name, argumentsDelta: args },
             {
               type: 'block-end',
               index,
-              block: { type: 'tool-call', id: CallId(id), name, arguments: args },
+              block: { type: 'tool-call', id: brandCallId(id), name, arguments: args },
             },
           )
           break

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ import { MAX_TIMER_DELAY_MS } from '@deepseek-ai/dsh-timeout'
 import { assertUsableApiKey, LlmError } from '@deepseek-ai/dsh-llm'
 import { credentialRef, type CredentialRef } from '@deepseek-ai/dsh-credentials'
 import { launchEnvironmentOf } from '@deepseek-ai/dsh-launch-environment'
-import { installSettingsSection, settingsNamespace } from '@deepseek-ai/dsh-settings'
+import * as dshSettings from '@deepseek-ai/dsh-settings'
 import { CommandCodeAdapter, DEFAULT_API_BASE, resolveAuthFileApiKey } from './adapter.ts'
 import { DEFAULT_REQUEST_TIMEOUT_MS, DEFAULT_STREAM_IDLE_TIMEOUT_MS } from './adapter.ts'
 import type { CommandCodeConnectionOptions, CommandCodeUsageReport } from './adapter.ts'
@@ -118,7 +118,11 @@ export type { CommandCodeAccountConfig, CommandCodeAccountSlot, CommandCodeAccou
 export const name = 'llm-commandcode'
 export const inject = ['llm']
 
-const NS = settingsNamespace('llm-commandcode')
+// dsh-settings 0.1.2-alpha.2 replaced the installSettingsSection/settingsNamespace
+// helpers with a SettingsProvider service; keep the old helpers when the runtime
+// still ships them so the plugin loads on both the rc and alpha channels.
+const { installSettingsSection, settingsNamespace } = dshSettings as any
+const NS = settingsNamespace === undefined ? 'llm-commandcode' : settingsNamespace('llm-commandcode')
 const DEFAULT_API_KEY_ENV = 'COMMANDCODE_API_KEY'
 
 /** The single provider route this plugin owns. */
@@ -435,12 +439,19 @@ export function apply(ctx: Context, config: Config): void {
   ctx.effect(() => () => loginFlow.dispose(), 'dsh-commandcode-provider: login flow')
   applyUsageRemote(ctx, { adapter, reports: usageReports, login: loginFlow })
 
-  installSettingsSection(ctx, NS, Config, config, {
-    setSource: (source) => {
+  const settingsHooks = {
+    setSource: (source: () => Config) => {
       current = source
     },
     // Everything the adapter reads is resolved per request, so a settings
     // change needs no registration-level action.
     onChange: () => {},
-  })
+  }
+  if (installSettingsSection !== undefined) {
+    installSettingsSection(ctx, NS, Config, config, settingsHooks)
+  } else {
+    (ctx as any).inject(['settings'], (settingsCtx: any) => {
+      settingsCtx.settings.installSection(ctx, NS, Config, config, settingsHooks)
+    })
+  }
 }


### PR DESCRIPTION
## Problem

dsh's current `@alpha` runtime (**0.1.2-alpha.2**) breaks the host entry at module-instantiation time, which aborts the **entire plugin tree** on a desktop profile:

1. **`@deepseek-ai/dsh-llm` renamed the `CallId` brand function to `ToolCallId`.** `src/adapter.ts` imports `CallId` by name; a missing named export is a `SyntaxError` at load, so dsh cannot boot at all with this plugin installed.
2. **`@deepseek-ai/dsh-settings` removed `installSettingsSection` / `settingsNamespace`** in favour of a `SettingsProvider` service (`ctx.inject(['settings'])` → `settings.installSection(owner, ns, schema, entry, hooks)`, plain-string namespaces).
3. **The web client targets rc.2-era modules** (`@deepseek-ai/dsh-client-runtime/client`, `@deepseek-ai/dsh-client-ui-primitives`) that do not exist in the alpha.2 runtime (that package has no alpha release at all). Loading the client entry aborts the whole client bootstrap — the page stays white with a `client-modules: require(...) missed the module table` error.

## Changes

- **Host side — dual-channel compatibility.** The tool-call id brand is resolved at runtime (`ToolCallId` on alpha, `CallId` on rc), and the settings section registers via `SettingsProvider.installSection` when the runtime ships it, falling back to the removed helpers otherwise. The plugin now loads on both the rc and alpha channels without any dependency churn.
- **Client side — manifest entry removed (temporary).** `dsh.client` is dropped so alpha.2 profiles get a working host instead of a white page. `src/client/` and its tests are kept for a future re-port against the current client-modules table. rc-only users lose the Models-page card until then.

## Verification

- `npm run typecheck` clean; `npm test` **228/228** pass (dev deps untouched, rc.6).
- `npm run build` OK.
- The alpha.2 path was exercised on a live `dsh 0.1.2-alpha.2` profile (the two host fixes are exactly what unblocks the plugin there).

## Notes for follow-up

The client re-port needs the alpha.2 client-modules table's replacement for `dsh-client-runtime/client` (the `createSnapshotStore` / `SettingsScope` providers) and the primitives module — happy to help if you have pointers to where those moved.