### PR TITLE
fix(adapter): honor explicit text-start/text-end boundaries; stop truncating interleaved reasoning

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1759,8 +1759,18 @@ export class CommandCodeAdapter<C extends CommandCodeConnectionOptions = Command
       if (!isRecord(event)) return chunks
 
       switch (event.type) {
+        case 'text-start':
+          // Commands Code emits explicit text-start/text-end to delimit the text block.
+          // Open the text block here (rather than lazily on the first text-delta) so
+          // block indexing matches the stream, and keep any still-open reasoning block
+          // intact — a text block and a reasoning block may coexist (BlockAssembler is
+          // index-scoped, so ordering is preserved by index).
+          if (textIndex < 0) {
+            textIndex = nextIndex++
+            chunks.push({ type: 'block-start', index: textIndex, blockType: 'text' })
+          }
+          break
         case 'text-delta': {
-          chunks.push(...closeReasoning())
           if (textIndex < 0) {
             textIndex = nextIndex++
             chunks.push({ type: 'block-start', index: textIndex, blockType: 'text' })
@@ -1771,8 +1781,13 @@ export class CommandCodeAdapter<C extends CommandCodeConnectionOptions = Command
           chunks.push({ type: 'text-delta', index: textIndex, text: delta })
           break
         }
-        case 'reasoning-delta': {
+        case 'text-end':
           chunks.push(...closeText())
+          break
+        case 'reasoning-start':
+          chunks.push(...closeText())
+          break
+        case 'reasoning-delta': {
           if (reasoningIndex < 0) {
             reasoningIndex = nextIndex++
             chunks.push({ type: 'block-start', index: reasoningIndex, blockType: 'reasoning' })
@@ -1782,9 +1797,6 @@ export class CommandCodeAdapter<C extends CommandCodeConnectionOptions = Command
           chunks.push({ type: 'reasoning-delta', index: reasoningIndex, text: delta })
           break
         }
-        case 'reasoning-start':
-          chunks.push(...closeText())
-          break
         case 'reasoning-end':
           chunks.push(...closeReasoning())
           break


### PR DESCRIPTION
## Problem

The Command Code stream emits `text-start`/`text-end` events to delimit the text block, but `handleEvent` only reacted to `text-delta`/`reasoning-delta`. This had two consequences:

1. `text-start`/`text-end` were silently dropped, so block indexing could diverge from the stream and the empty phases were handled inconsistently.
2. `text-delta` called `closeReasoning()` unconditionally. On an interleaved stream (model thinking-and-speaking — reasoning followed by text and then more reasoning), this closed the still-open reasoning block early, splitting one continuous reasoning stream into several fragments and pushing trailing reasoning into the `text` block. `reasoning-delta` did the mirror-image thing with `closeText()`.

## Fix

- Add `text-start`/`text-end` cases (open/close the text block on the explicit boundary).
- Drop the unconditional `closeReasoning()`/`closeText()` calls inside `text-delta`/`reasoning-delta`.

Rationale: reasoning and text blocks can coexist; the harness `BlockAssembler` is **index-scoped** (one partial per index, ordered by index), so preserving an open reasoning block while the text block advances keeps stream ordering correct.

## Verification

Verified with a real Command Code `/alpha/generate` stream:
- **Sequential stream** (reasoning then text, `reasoning-end` after `text-start`): unchanged — reasoning and text blocks are separated exactly as before.
- **Interleaved reasoning/text**: the original split one continuous reasoning into 2 fragments; the fix keeps it as 1 block.