### PR TITLE
fix: stop named-importing CallId/ToolCallId from dsh-llm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Do not named-import `CallId` / `ToolCallId` from `@deepseek-ai/dsh-llm`.** rc.6 / 0.1.1-rc.1 export `CallId`; 0.1.2-alpha.1 renamed that constructor to `ToolCallId`. A missing named ESM export throws `does not provide an export named 'CallId'` and the whole plugin tree fails to load. The adapter now brands tool-call ids through the host `StreamChunk` vocabulary instead of importing either constructor name. See [deepseek-ai/deepseek-harness#4827](https://github.com/deepseek-ai/deepseek-harness/discussions/4827).
+
 ## [0.10.0-alpha.5] - 2026-09-02
 
 > **Alpha channel for dsh 0.1.2-alpha.2.** This release requires **dsh 0.1.2-alpha.2 or later** and is published under the `alpha` npm tag, so `@latest` stays on 0.9.1 for older Harness releases. Install it explicitly with `@alpha`.

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -33,7 +33,6 @@ import {
   LlmAdapter,
   LlmError,
   ReasoningEffortId,
-  ToolCallId,
   errorChain,
   resolveRetryPolicy,
   type ResolvedRetryPolicy,
@@ -48,6 +47,18 @@ import {
   type TokenUsage,
 } from '@deepseek-ai/dsh-llm'
 import { RETRY_MAX_DELAY_MS } from './accounts.ts'
+
+/**
+ * Brand a provider-issued tool-call id through the host chunk vocabulary.
+ *
+ * Do not named-import `CallId` / `ToolCallId` from `@deepseek-ai/dsh-llm`.
+ * rc.6 / 0.1.1-rc.1 export `CallId`; 0.1.2-alpha.1 renamed that constructor
+ * to `ToolCallId`. A missing named ESM export fails plugin-tree load before
+ * any adapter code runs (deepseek-ai/deepseek-harness#4827).
+ */
+function toolCallId(id: string): Extract<StreamChunk, { type: 'tool-call-delta' }>['id'] {
+  return id as Extract<StreamChunk, { type: 'tool-call-delta' }>['id']
+}
 
 // ---------------------------------------------------------------------------
 // Static capability snapshot (from the official command-code@1.40.1 bundled
@@ -1816,11 +1827,11 @@ export class CommandCodeAdapter<C extends CommandCodeConnectionOptions = Command
           sawContent = true
           chunks.push(
             { type: 'block-start', index, blockType: 'tool-call' },
-            { type: 'tool-call-delta', index, id: ToolCallId(id), name, argumentsDelta: args },
+            { type: 'tool-call-delta', index, id: toolCallId(id), name, argumentsDelta: args },
             {
               type: 'block-end',
               index,
-              block: { type: 'tool-call', id: ToolCallId(id), name, arguments: args },
+              block: { type: 'tool-call', id: toolCallId(id), name, arguments: args },
             },
           )
           break

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -10,7 +10,8 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { rmSync } from 'node:fs'
+import { readFileSync, rmSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 
 import {
   CommandCodeAdapter,
@@ -120,6 +121,18 @@ async function collect(stream: AsyncIterable<StreamChunk>): Promise<StreamChunk[
   for await (const chunk of stream) out.push(chunk)
   return out
 }
+
+// ---------------------------------------------------------------------------
+// Host export compatibility
+// ---------------------------------------------------------------------------
+
+test('adapter does not named-import CallId or ToolCallId from @deepseek-ai/dsh-llm', () => {
+  const src = readFileSync(fileURLToPath(new URL('../src/adapter.ts', import.meta.url)), 'utf8')
+  assert.doesNotMatch(
+    src,
+    /import\s*\{[\s\S]*?\b(?:CallId|ToolCallId)\b[\s\S]*?\}\s*from\s*['"]@deepseek-ai\/dsh-llm['"]/,
+  )
+})
 
 // ---------------------------------------------------------------------------
 // Message conversion (via stream() request capture)


### PR DESCRIPTION
## Summary
Desktop / dsh `0.1.2-alpha.1` fails to load `@mars-sea/dsh-commandcode-provider@latest` (`0.9.1`) with:

```
The requested module '@deepseek-ai/dsh-llm' does not provide an export named 'CallId'
```

`@deepseek-ai/dsh-llm` renamed the branded `CallId` constructor to `ToolCallId` in `0.1.2-alpha.1`. A named ESM import of the missing name fails at instantiation and the whole plugin tree dies ([deepseek-ai/deepseek-harness#4827](https://github.com/deepseek-ai/deepseek-harness/discussions/4827)).

A previous attempt (#9) switched the named import to `ToolCallId`, which would then break rc hosts that still export `CallId`. Copilot's review asked for a namespace fallback instead of a hard named import.

This PR brands tool-call ids through the host `StreamChunk` vocabulary (`Extract<StreamChunk, { type: 'tool-call-delta' }>['id']`) and does not import either constructor name. Same pattern as `ai/adapt-dsh-0.1.2`.

## Changes
- `src/adapter.ts` — local `toolCallId()` helper; drop `ToolCallId` from the `@deepseek-ai/dsh-llm` value import
- `tests/adapter.test.ts` — regression that the adapter must not named-import `CallId` or `ToolCallId`
- `CHANGELOG.md` — Unreleased note

## Test plan
- [x] `node --import tsx --test tests/adapter.test.ts` (71 pass)
- [ ] Confirm a cold boot on dsh 0.1.2-alpha.1 / alpha.2 no longer throws the named-export SyntaxError
- [ ] Send a tool-calling turn and confirm `tool-call` / `tool-call-delta` ids still round-trip

## Note for 0.9.x / `@latest`
Current `main` is the `0.10.0-alpha` line (`@alpha`, dsh ≥ 0.1.2-alpha.2). Desktop users on `0.1.2-alpha.1` still install `@latest` **0.9.1**, which is the line that still `import { CallId }`.

The same adapter change is on `yyh-001:fix/0.9.2-callid-compat` (based on `v0.9.1`, version bumped to 0.9.2, peers include `0.1.2-alpha.1`). Please cut a `0.9.x` branch from `v0.9.1` and publish **0.9.2** to the `latest` tag so Desktop alpha.1 users stop hitting this on install. That branch should not be merged into `main`.